### PR TITLE
Support for max texture size on some GPUs

### DIFF
--- a/lib/sphere.js
+++ b/lib/sphere.js
@@ -47,6 +47,7 @@ Photosphere.prototype.cropImage = function(){
 		context.fillStyle = "#000";
 		context.fillRect(0,0,canvas.width,canvas.height);
 		context.drawImage(img, self.exif['x'], self.exif['y'], self.exif['crop_width'], self.exif['crop_height']);
+		
 		self.start3D( canvas.toDataURL("image/png") );
 	}
 	img.src = this.image;
@@ -313,13 +314,28 @@ Photosphere.prototype.loadEXIF = function(callback){
 			return xmpp.substring( x, xmpp.indexOf('"', x) );
 		};
 
+		// We have to resize the max width of the picture to the
+		// max supported texture width of the GPU in case we are
+		// in WebGL mode:
+		ratio = 1.0;
+		if(self.canDoWebGL()){
+			canvas  = document.createElement('canvas');
+			ctx     = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+			max_size = ctx.getParameter(ctx.MAX_TEXTURE_SIZE);
+			console.log("Max texture size: " + max_size);
+			ratio = max_size/getAttr("GPano:FullPanoWidthPixels");
+		}
+
+		// Check https://developers.google.com/panorama/metadata/
+		// for an explanation of what those parameters mean
+		// including what parameters have to be scaled:
 		self.exif = {
-			"full_width" : getAttr("GPano:FullPanoWidthPixels"),
-			"full_height" : getAttr("GPano:FullPanoHeightPixels"),
-			"crop_width" : getAttr("GPano:CroppedAreaImageWidthPixels"),
-			"crop_height" : getAttr("GPano:CroppedAreaImageHeightPixels"),
-			"x" : getAttr("GPano:CroppedAreaLeftPixels"),
-			"y" : getAttr("GPano:CroppedAreaTopPixels")
+			"full_width" : getAttr("GPano:FullPanoWidthPixels")*ratio,
+			"full_height" : getAttr("GPano:FullPanoHeightPixels")*ratio,
+			"crop_width" : getAttr("GPano:CroppedAreaImageWidthPixels")*ratio,
+			"crop_height" : getAttr("GPano:CroppedAreaImageHeightPixels")*ratio,
+			"x" : getAttr("GPano:CroppedAreaLeftPixels")*ratio,
+			"y" : getAttr("GPano:CroppedAreaTopPixels")*ratio
 		}
 		console.log(self.exif);
 		callback();


### PR DESCRIPTION
Scale the image and its parameters to avoid going over the max 2D texture
size supported on WebGL on a particular browser. Tested on Chrome. On my 2011 Macbook pro, this was necessary.
