### PR TITLE
Update sphere.js

### DIFF
--- a/lib/sphere.js
+++ b/lib/sphere.js
@@ -149,7 +149,7 @@ Photosphere.prototype.start3D = function(image){
 Photosphere.prototype.startMoving = function(){
 	self = this;
 	this.interval = setInterval(function(){
-		self.lon = self.lon - 0.1;
+		self.lon = self.lon + 0.1;
 		
 		if( -3 < self.lat && self.lat < 3){}
 		else if(self.lat > 10){ self.lat -= 0.1 }
@@ -344,7 +344,7 @@ Photosphere.prototype.loadEXIF = function(callback){
 		getAttr = function(attr){
 			x = xmpp.indexOf(attr) + attr.length;
 			s = xmpp.substring( x );
-			return s.match(/[0-9]+/);
+			return s.match(/[0-9]+/)[0];
 		};
 
 		self.exif = {

--- a/lib/sphere.js
+++ b/lib/sphere.js
@@ -338,9 +338,11 @@ Photosphere.prototype.loadEXIF = function(callback){
 		xmpEnd = "</x:xmpmeta>";
 		xmpp = data.substring(data.indexOf("<x:xmpmeta"), data.indexOf(xmpEnd) + xmpEnd.length);
 
+// 2014-02-26 ericball - modified getAttr to handle exiftool tags e.g. <GPano:FullPanoWidthPixels>3000</GPano:FullPanoWidthPixels>
 		getAttr = function(attr){
-			x = xmpp.indexOf(attr+'="') + attr.length + 2;
-			return xmpp.substring( x, xmpp.indexOf('"', x) );
+			x = xmpp.indexOf(attr) + attr.length;
+			s = xmpp.substring( x );
+			return s.match(/[0-9]+/);
 		};
 
 		self.exif = {

--- a/lib/sphere.js
+++ b/lib/sphere.js
@@ -6,9 +6,10 @@
 // Usage: new Photosphere("image.jpg").loadPhotosphere(document.getElementById("myPhotosphereID"));
 // myPhotosphereID must have width/height specified!
 
-
-function Photosphere(image){
+// 2014-03-03 ericball - added optional vertical field of view parameter
+function Photosphere(image, vFoV){
 	this.image = image;
+	this.vFov = (typeof vFoV === "undefined") ? 75 : vFoV;
 	//this.worker = new Worker("worker.js");
 }
 
@@ -108,7 +109,8 @@ Photosphere.prototype.start3D = function(image){
 	this.lat = 0; this.lon = 90;
 	this.onMouseDownMouseX = 0, this.onMouseDownMouseY = 0, this.isUserInteracting = false, this.onMouseDownLon = 0, this.onMouseDownLat = 0;
 
-	this.camera = new THREE.PerspectiveCamera( 75, parseInt(this.holder.offsetWidth) / parseInt(this.holder.offsetHeight), 1, 1100 );
+// 2014-03-03 ericball - added optional vertical field of view parameter
+	this.camera = new THREE.PerspectiveCamera( this.vFoV, parseInt(this.holder.offsetWidth) / parseInt(this.holder.offsetHeight), 1, 1100 );
 	this.scene = new THREE.Scene();
 	mesh = new THREE.Mesh( new THREE.SphereGeometry( 200, 20, 40 ), this.loadTexture( image ) );
 	mesh.scale.x = - 1;


### PR DESCRIPTION
I ran into a problem trying to use sphere.js to display a pano with GPano tags created by exiftool.  I found the problem was a conflict between the getAttr function (which expects GPano:FullPanoWidthPixels="3000") and the tags created by exiftool (which are the format < GPano:FullPanoWidthPixels >3000< /GPano:FullPanoWidthPixels >.
